### PR TITLE
Component rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ Hyperscript syntax for React.js markup.
 
 ```js
 var h = require('react-hyperscript');
-var React = require('react');
 
-module.exports = React.createClass({
+var AnotherComponent = require('./another-component');
+
+module.exports = h.createClass({
   render: function render() {
     return (
       h('div.example', [
         h('h1#heading', 'This is hyperscript'),
         h('h2', 'creating React.js markup'),
-        h('ul', [
+        h(AnotherComponent, {foo: 'bar'}, [
           h('li', [
             h('a', {href: 'http://whatever.com'}, 'One list item')
           ]),
@@ -28,14 +29,15 @@ module.exports = React.createClass({
 
 ## Documentation
 
-#### `h(selector, properties, children)`
+#### `h(componentOrTag, properties, children)`
 
-Returns a React.DOM element.
+Returns a React element.
 
-- **selector** `String` - Takes a tag name and optional class names or id in the
-format `h1#some-id.foo.bar`. It will parse out the tag name and change the `id`
-and `className` properties of the `properties` object.
+- **componentOrTag** `Object|String` - Can be a React component **OR** tag
+string with optional css class names/id in the format `h1#some-id.foo.bar`.
+If a tag string, it will parse out the tag name and change the `id` and
+`className` properties of the `properties` object.
 - **properties** `Object` *(optional)* - An object containing the properties
-you'd like the set on the React.DOM element.
-- **children** `Array` or `String` *(optional)* - An array of `h()` children or
+you'd like to set on the element.
+- **children** `Array|String` *(optional)* - An array of `h()` children or
 a string. This will create child elements or a text node, respectively.

--- a/index.js
+++ b/index.js
@@ -2,30 +2,39 @@
 var parseTag = require('virtual-hyperscript/parse-tag');
 var React = require('react');
 
-function h(selector, properties, children) {
+module.exports = h;
+
+function h(componentOrTag, properties, children) {
+  properties = properties || {};
+
   // If a child array or text node are passed as the second argument, shift them
   if (!children && isChildren(properties)) {
     children = properties;
     properties = {};
   }
 
-  // Parse the tag name and fill out the properties
-  properties = properties || {};
-  var tagName = parseTag(selector, properties);
-
-  // Throw an error if the tag is invalid
-  var reactDOMCreator = React.DOM[tagName];
-  if (!reactDOMCreator) {
-    throw new Error('React does not support the `' + tagName + '` tag');
+  if (typeof componentOrTag === 'string') {
+    componentOrTag = getTagFn(componentOrTag, properties);
   }
 
   // Call React.DOM
   var args = [properties].concat(children);
-  return reactDOMCreator.apply(React.DOM, args);
+  return componentOrTag.apply(React.DOM, args);
+}
+
+function getTagFn(tag, properties) {
+  // Parse the tag name and fill out the properties
+  var tagName = parseTag(tag, properties);
+
+  // Throw an error if the tag is invalid
+  var tagFn = React.DOM[tagName];
+  if (!tagFn) {
+    throw new Error('React does not support the `' + tagName + '` tag');
+  }
+
+  return tagFn;
 }
 
 function isChildren(x) {
   return typeof x === 'string' || Array.isArray(x);
 }
-
-module.exports = h;

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,60 @@ test('A tag with a children array as the second argument', function t(assert) {
   assert.end();
 });
 
+test('A component', function t(assert) {
+  assert.plan(1);
+
+  var dom = renderTestComponent();
+
+  assert.equal(dom, '<div><h1></h1></div>',
+    'renders the component correctly');
+  assert.end();
+});
+
+test('A component with props and children', function t(assert) {
+  assert.plan(1);
+
+  var dom = renderTestComponent({title: 'Hello World!'}, [
+    h('span', 'A child')
+  ]);
+
+  assert.equal(dom, '<div><h1>Hello World!</h1><span>A child</span></div>',
+    'renders the component with children and props correctly');
+  assert.end();
+});
+
+test('A component with children', function t(assert) {
+  assert.plan(1);
+
+  var dom = renderTestComponent([
+    h('span', 'A child')
+  ]);
+
+  assert.equal(dom, '<div><h1></h1><span>A child</span></div>',
+    'renders the component with children correctly');
+  assert.end();
+});
+
+function renderTestComponent() {
+  // Create a test component
+  var Component = React.createClass({
+    render: function render() {
+      return (
+        h('div', [
+          h('h1', this.props.title),
+          this.props.children
+        ])
+      );
+    }
+  });
+
+  // Render it with the passed args
+  var args = Array.prototype.slice.call(arguments);
+  args.unshift(Component);
+  var component = h.apply(h, args);
+  return getDOMString(component);
+}
+
 function getDOMString(reactDOM) {
   // Remove react id and checksum from resulting dom string
   return React.renderComponentToString(reactDOM)


### PR DESCRIPTION
This adds support to render components inline with `h(component)`. This makes way for easily supporting React `v0.12` by allowing us to call `React.createElement(component)` for the user. [More information](https://gist.github.com/sebmarkbage/ae327f2eda03bf165261).

[New documentation here](https://github.com/mlmorg/react-hyperscript/blob/55aee37474d798e8ff2c6ad3037ed33b8a3f4322/README.md)

cc @Raynos @malandrew @ross- @lxe
