### PR TITLE
Support dataset and attributes keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,23 +12,23 @@ function h(componentOrTag, properties, children) {
   }
 
   properties = properties || {};
-  
+
   // Supported nested dataset attributes
-	if (properties.dataset) {
-		Object.keys(properties.dataset).forEach(function (attrName) {
-			var dashedAttr = attrName.replace(/([a-z])([A-Z])/, function(match) {
-				return match[0] + '-' + match[1].toLowerCase();
-			})
-			properties['data-'+dashedAttr] = properties.dataset[attrName];
-		});
-	}
+  if (properties.dataset) {
+    Object.keys(properties.dataset).forEach(function unnest(attrName) {
+      var dashedAttr = attrName.replace(/([a-z])([A-Z])/, function dash(match) {
+        return match[0] + '-' + match[1].toLowerCase();
+      });
+      properties['data-' + dashedAttr] = properties.dataset[attrName];
+    });
+  }
 
   // Support nested attributes
-	if (properties.attributes) {
-		Object.keys(properties.attributes).forEach(function (attrName) {
-			properties[attrName] = properties.attributes[attrName];
-		});
-	}
+  if (properties.attributes) {
+    Object.keys(properties.attributes).forEach(function unnest(attrName) {
+      properties[attrName] = properties.attributes[attrName];
+    });
+  }
 
   // When a selector, parse the tag name and fill out the properties object
   if (typeof componentOrTag === 'string') {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,23 @@ function h(componentOrTag, properties, children) {
   }
 
   properties = properties || {};
+  
+  // Supported nested dataset attributes
+	if (properties.dataset) {
+		Object.keys(properties.dataset).forEach(function (attrName) {
+			var dashedAttr = attrName.replace(/([a-z])([A-Z])/, function(match) {
+				return match[0] + '-' + match[1].toLowerCase();
+			})
+			properties['data-'+dashedAttr] = properties.dataset[attrName];
+		});
+	}
+
+  // Support nested attributes
+	if (properties.attributes) {
+		Object.keys(properties.attributes).forEach(function (attrName) {
+			properties[attrName] = properties.attributes[attrName];
+		});
+	}
 
   // When a selector, parse the tag name and fill out the properties object
   if (typeof componentOrTag === 'string') {


### PR DESCRIPTION
In the virtual-dom hyperscript implementation, the properties `dataset` and `attributes` are nested properties that get translated onto the resulting node: https://github.com/Matt-Esch/virtual-dom/blob/903d884a8e4f05f303ec6f2b920a3b5237cf8b92/test/nested-properties.js#L45-L74

This does the same behaviour, allowing this project to support the use case of someone converting a project from virtual-dom to react-dom i.e. my use case :)

Cheers,
-glen.