### PR TITLE
Copy properties object to support inextensible records

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function h(componentOrTag, properties, children) {
     children = [];
   }
 
-  properties = properties || {};
+  properties = properties ? Object.assign({}, properties) : {};
 
   // Supported nested dataset attributes
   if (properties.dataset) {

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var test = require('tape');
 var h = require('../');
 
 var Component = createComponent();
+var FunctionComponent = createFunctionComponent();
 
 var renderTests = {
   'basic html tag': {
@@ -86,6 +87,10 @@ var renderTests = {
   'component with children in props': {
     dom: h(Component, {children: [h('span', 'A child')]}),
     html: '<div><h1></h1><span>A child</span></div>'
+  },
+  'function component with children': {
+    dom: h(FunctionComponent, [h('span', 'A child')]),
+    html: '<div class="a-class"><span>A child</span></div>'
   }
 };
 
@@ -117,6 +122,14 @@ function createComponent() {
       );
     }
   });
+}
+
+function createFunctionComponent() {
+  return function(props) {
+    return (
+      h('div.a-class', props)
+    );
+  }
 }
 
 function getDOMString(reactElement) {


### PR DESCRIPTION
For example, when doing something like:

```js
const SomeComponent = (props) => (
  h('.some-class', props)
);
```

It fails at `TypeError: Can't add property className, object is not extensible`
because the `props` object that React passes to pure function components is
frozen and/or marked as inextensible.

This PR makes sure we copy the properties object using `Object.assign` on each
call.