### PR TITLE
add way to replace `React.createElement` function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var React = require('react');
 var parseTag = require('./parse-tag');
 
 module.exports = h;
+module.exports.createElement = React.createElement
 
 function h(componentOrTag, properties, children) {
   // If a child array or text node are passed as the second argument, shift them
@@ -42,7 +43,7 @@ function h(componentOrTag, properties, children) {
 
   // Create the element
   var args = [componentOrTag, properties].concat(children);
-  return React.createElement.apply(React, args);
+  return module.exports.createElement.apply(React, args);
 }
 
 function isChildren(x) {


### PR DESCRIPTION
I wanted to use this package with https://github.com/calmm-js/karet (and also https://github.com/infernojs/inferno, but mostly `karet`) and doesn't seem to be a way, unless I forked it just to replace the `react` import with `karet`. But I guess this solves all the problems while still keeping everything working as it is.

Now if I want to use `karet` I can do

```js
const h = require('react-hyperscript')
h.createElement = require('karet').createElement
```

and use it normally.