### PR TITLE
Support React 16

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ function h(componentOrTag, properties, children) {
       });
       properties['data-' + dashedAttr] = properties.dataset[attrName];
     });
+
+    properties.dataset = undefined;
   }
 
   // Support nested attributes
@@ -33,6 +35,8 @@ function h(componentOrTag, properties, children) {
     Object.keys(properties.attributes).forEach(function unnest(attrName) {
       properties[attrName] = properties.attributes[attrName];
     });
+
+    properties.attributes = undefined;
   }
 
   // When a selector, parse the tag name and fill out the properties object

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
   ],
   "main": "index.js",
   "peerDependencies": {
-    "react": ">= 0.12.0 < 16.0.0"
+    "react": ">= 0.12.0 < 17.0.0"
   },
   "devDependencies": {
+    "create-react-class": "^15.6.2",
     "eslint": "^2.0.0",
     "eslint-config-mlmorg": "^2.0.0",
-    "react": ">= 0.12.0 < 16.0.0",
-    "react-dom": "^15.0.0",
+    "react": ">= 0.12.0 < 17.0.0",
+    "react-dom": "^16.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict';
 var console = require('console');
-var React = require('react');
 var ReactDOM = require('react-dom/server');
 var test = require('tape');
+var createReactClass = require('create-react-class');
 
 var h = require('../');
 
@@ -112,7 +112,7 @@ test('Tags rendered with different arguments', function t(assert) {
 });
 
 function createComponent() {
-  return React.createClass({
+  return createReactClass({
     render: function render() {
       return (
         h('div', [


### PR DESCRIPTION
We are already using `react-hyperscript` with react 16 in production since a couple of weeks, so far we haven’t encountered any problem. So I think it would make sense to make it transparent that `react-hyperscript` supports react 16 and the annoying warning during `npm install` should also go away.