### PR TITLE
Fix tests that check for absence of react warnings

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ var renderTests = {
     html: '<div><h1></h1><span>A child</span></div>'
   },
   'component with children in props': {
-    dom: h(Component, {children: [h('span', 'A child')]}),
+    dom: h(Component, {children: [h('span', { key: 'any-key' }, 'A child')]}),
     html: '<div><h1></h1><span>A child</span></div>'
   },
   'function component with children': {

--- a/test/index.js
+++ b/test/index.js
@@ -141,9 +141,12 @@ function catchWarns(fn) {
 
   /* eslint-disable no-console */
   var originalWarn = console.warn;
+  var originalError = console.error;
   console.warn = warn;
+  console.error = warn;
   fn();
   console.warn = originalWarn;
+  console.error = originalError;
   /* esline-enable no-console */
 
   return messages;

--- a/test/index.js
+++ b/test/index.js
@@ -102,7 +102,7 @@ test('Tags rendered with different arguments', function t(assert) {
       dom = getDOMString(data.dom);
     });
 
-    assert.equal(messages.length, 0,
+    assert.deepEqual(messages, [],
       '`' + name + '` does not log warnings');
 
     assert.equal(dom, data.html,


### PR DESCRIPTION
Recent versions of React are using `console.error` instead of `console.warn` which is why `catchWarns` didn’t work anymore and the tests were not failing although we had a test that produces a warning.
Now also `console.error` will also be stubbed.