### PR TITLE
Add missing license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "bugs": {
     "url": "https://github.com/mlmorg/react-hyperscript/issues"
   },
+  "license": "MIT",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
npm warns about a missing `license` field when installing
`react-hyperscript`.

```
npm WARN react-hyperscript@3.1.0 No license field.
```