### PR TITLE
Add support for render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ If a tag string, it will parse out the tag name and change the `id` and
 `className` properties of the `properties` object.
 - **properties** `Object` *(optional)* - An object containing the properties
 you'd like to set on the element.
-- **children** `Array|String` *(optional)* - An array of `h()` children or
-a string. This will create child elements or a text node, respectively.
+- **children** `Array|String|Number|Function` *(optional)* - An array of `h()`
+children, string, number, or a function.
 - **listOfElements** `Array` - An array of React elements that will be wrapped with `React.Fragment`.

--- a/index.js
+++ b/index.js
@@ -53,5 +53,10 @@ function h(componentOrTag, properties, children) {
 }
 
 function isChildren(x) {
-  return typeof x === 'string' || typeof x === 'number' || Array.isArray(x);
+  return (
+    typeof x === 'string' ||
+    typeof x === 'number' ||
+    typeof x === 'function' ||
+    Array.isArray(x)
+  );
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var h = require('../');
 
 var Component = createComponent();
 var FunctionComponent = createFunctionComponent();
+var RenderPropComponent = createRenderPropComponent();
 
 var renderTests = {
   'basic html tag': {
@@ -88,6 +89,10 @@ var renderTests = {
     dom: h(Component, {children: [h('span', { key: 'any-key' }, 'A child')]}),
     html: '<div><h1></h1><span>A child</span></div>'
   },
+  'component with render prop': {
+    dom: h(RenderPropComponent, function(text) { return h('span', text) }),
+    html: '<div><span>Hello from render prop</span></div>'
+  },
   'function component with children': {
     dom: h(FunctionComponent, [h('span', 'A child')]),
     html: '<div class="a-class"><span>A child</span></div>'
@@ -132,6 +137,14 @@ function createFunctionComponent() {
   return function(props) {
     return (
       h('div.a-class', props)
+    );
+  }
+}
+
+function createRenderPropComponent() {
+  return function(props) {
+    return (
+      h('div', null, props.children('Hello from render prop'))
     );
   }
 }


### PR DESCRIPTION
Hey there!

This PR makes a tiny change make usage of render props a bit easier. Render props seems to be all the rage right now and with the upcoming React 16.3 context API, they have essentially been "blessed" by the core React team.

This PR make this possible:
```js
h(Context.Consumer, context => { ...})
```

Whereas previously it was necessary to step over `null`:
```js
h(Context.Consumer, null, context => { ...})
```

Implications:

If some of your users do something like:

```js
function foo() {}
foo.bar = "baz"

const element = h("div", foo)
```

...and expect `element.props` to be `{bar: "baz"}`, this change will break their code. For this reason this could/should be considered a breaking change.

Test are updated and passing, README has been updated.